### PR TITLE
Fix enumerateContacts onCompleted.

### DIFF
--- a/Sources/RxContacts.swift
+++ b/Sources/RxContacts.swift
@@ -116,8 +116,8 @@ extension Reactive where Base: CNContactStore {
             do {
                 try self.base.enumerateContacts(with: fetchRequest, usingBlock: { contact, pointer in
                     observer.onNext((contact, pointer))
-                    observer.onCompleted()
                 })
+                observer.onCompleted()
                 
             } catch {
                 observer.onError(error)


### PR DESCRIPTION
Hello, @satishbabariya 

Same PR : #1 
When enumeration of all contacts on `enumerateContacts`, onCompleted() call.

Before
![image](https://user-images.githubusercontent.com/11539551/95823390-8095e880-0d68-11eb-8def-71b33936d1de.png)

After
![image](https://user-images.githubusercontent.com/11539551/95823362-6f4cdc00-0d68-11eb-88fe-5d68368bd4de.png)

P.S.
CocoaPods version is not 1.0.3
Please update the CocoaPods library.